### PR TITLE
Bucket latch only activates after intake trigger is released

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/MainTeleOp.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmodes/MainTeleOp.java
@@ -1,5 +1,6 @@
 package org.firstinspires.ftc.teamcode.opmodes;
 
+import static com.arcrobotics.ftclib.gamepad.GamepadKeys.Button.A;
 import static com.arcrobotics.ftclib.gamepad.GamepadKeys.Button.B;
 import static com.arcrobotics.ftclib.gamepad.GamepadKeys.Button.DPAD_DOWN;
 import static com.arcrobotics.ftclib.gamepad.GamepadKeys.Button.DPAD_LEFT;
@@ -153,6 +154,7 @@ public final class MainTeleOp extends LinearOpMode {
                 );
 
                 if (gamepadEx1.wasJustPressed(X))               robot.intake.toggle();
+                if (gamepadEx1.wasJustPressed(A))               robot.intake.dumpSample();
 //                if (keyPressed(gamepadEx1, Y))               robot.climber.climb();
 //
 //                if (robot.climber.isActive()) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Deposit.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Deposit.java
@@ -51,7 +51,7 @@ public final class Deposit {
             HEIGHT_BASKET_HIGH = 32,
             HEIGHT_CHAMBER_LOW = 20,
             HEIGHT_CHAMBER_HIGH = 32,
-            HEIGHT_OFFSET_SPECIMEN_SCORING = -7;
+            HEIGHT_OFFSET_SPECIMEN_SCORING = -10;
 
     /**
      * HSV value bound for specimen detection

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Deposit.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Deposit.java
@@ -183,7 +183,7 @@ public final class Deposit {
 
         arm.updateAngles(
                 ANGLE_ARM_RETRACTED,
-                state == INTAKING_SPECIMEN || state == HAS_SPECIMEN ? ANGLE_ARM_SPECIMEN : ANGLE_ARM_SAMPLE
+                handlingSpecimen() ? ANGLE_ARM_SPECIMEN : ANGLE_ARM_SAMPLE
         );
 
         claw.updateAngles(
@@ -200,6 +200,10 @@ public final class Deposit {
         lift.run(intakeClearOfDeposit);
 
         if (arm.isActivated()) timeSinceArmExtended.reset();
+    }
+
+    private boolean handlingSpecimen() {
+        return state == INTAKING_SPECIMEN || state == HAS_SPECIMEN;
     }
 
     boolean isActive() {
@@ -302,7 +306,7 @@ public final class Deposit {
     void printTelemetry() {
         mTelemetry.addLine("DEPOSIT: " + state);
         mTelemetry.addLine();
-        mTelemetry.addLine(hasSample() ? sample + " sample" : "Empty");
+        mTelemetry.addLine(hasSample() ? sample + (handlingSpecimen() ? " specimen" : " sample") : "Empty");
         hsv.toTelemetry();
         divider();
         lift.printTelemetry();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Intake.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Intake.java
@@ -202,7 +202,7 @@ public final class Intake {
                     state = BUCKET_PIVOTING;
                     timer.reset();
                 } else {
-                    if (hasSample()) setExtended(false);
+                    if (hasSample() && motor.get() == 0) setExtended(false);
                     break;
                 }
 
@@ -242,7 +242,7 @@ public final class Intake {
         latch.updateAngles(ANGLE_LATCH_UNLOCKED, ANGLE_LATCH_LOCKED);
         extendo.updateAngles(ANGLE_EXTENDO_RETRACTED, ANGLE_EXTENDO_EXTENDED_MAX);
 
-        latch.setActivated(hasSample());    // latch activates when sample present, otherwise deactivates
+        latch.setActivated(hasSample() && motor.get() == 0);    // latch activates when sample present, otherwise deactivates
 
         bucket.run();
         latch.run();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Intake.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Intake.java
@@ -254,6 +254,10 @@ public final class Intake {
         extendo.run();
     }
 
+    public void dumpSample() {
+        if (state == INTAKING && sample != null) sample = badSample;
+    }
+
     private boolean hasSample() {
         return sample != null;
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Intake.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Intake.java
@@ -41,6 +41,7 @@ public final class Intake {
             DISTANCE_EXTENDO_RETRACTED = 0,
             DISTANCE_EXTENDO_EXTENDED_MIN = 25.19855,
             DISTANCE_EXTENDO_EXTENDED_MAX = 410,
+            DISTANCE_DUMPING_MIN = 200,
 
             ANGLE_EXTENDO_RETRACTED = 16,
             ANGLE_EXTENDO_EXTENDED_MAX = 70,
@@ -198,9 +199,13 @@ public final class Intake {
                 sample = hsvToSample(hsv);      // if color sensor found sample, hasSample() returns true
 
                 if (sample == badSample) {
+
+                    if (extendedLength < DISTANCE_DUMPING_MIN) break;
+                    
                     bucket.setActivated(false);
                     state = BUCKET_PIVOTING;
                     timer.reset();
+
                 } else {
                     if (hasSample() && motor.get() == 0) setExtended(false);
                     break;


### PR DESCRIPTION
- Allows the sample to fall all the way into the bucket so it does not get kicked up
- Deposit telemetry reads BLUE/RED specimen instead of sample when intaking or carrying a specimen
- Added keybind for dumping samples
- Auto-dumping samples only works when extended enough (to prevent jams)
- Lift pulls specimens down further when scoring them